### PR TITLE
Coffee script dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@danielkalen/listr": "^0.5.0",
     "chalk": "^1.1.3",
+    "coffee-script": "^1.10.0",
     "glob": "^6.0.4",
     "node-status": "^0.1.7",
     "yargs": "^3.29.0"
@@ -37,7 +38,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
-    "coffee-script": "^1.10.0",
     "create-output-stream": "0.0.1",
     "execa": "^0.4.0",
     "fs-extra": "^0.30.0",


### PR DESCRIPTION
Should fix `Error: Cannot find module 'coffee-script/register'` when you don't use coffee script in your project or don't have it globally installed.