### PR TITLE
ADD the glob option `nodir` & version minor to `1.8.0`

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -12,6 +12,7 @@ suppliedOptions =
 	'glob': args.g or args.glob or args._[0]
 	'command': args.x or args.execute or args._[1]
 	'ignore': args.i or args.ignore
+	'nodir': args.nd or args.nodir
 	'trim': args.t or args.trim
 	'forceColor': args.c or args.forceColor
 	'concurrent': args.C or args.concurrent

--- a/lib/cliOptions.coffee
+++ b/lib/cliOptions.coffee
@@ -7,6 +7,10 @@ module.exports =
 		alias: 'ignore'
 		describe: 'Glob ignore'
 		type: 'string'
+	'nd':
+		alias: 'nodir'
+		describe: 'Ignore directories (folders)'
+		type: 'boolean'
 	'x':
 		alias: 'execute'
 		describe: 'Command to execute upon file addition/change'

--- a/lib/foreach.coffee
+++ b/lib/foreach.coffee
@@ -11,6 +11,7 @@ module.exports = (options)-> new Promise (finish)->
 	finalLogs = 'log':{}, 'error':{}
 	globOptions = {}
 	if options.ignore then globOptions.ignore = options.ignore
+	if options.nodir then globOptions.nodir = options.nodir
 
 	glob options.glob, globOptions, (err, files)-> if err then return console.error(err) else
 		tasks = new Listr files.map((file)=>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreach-cli",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "CLI util to execute a command for each file matching a glob",
   "keywords": [
     "cli",

--- a/test/samples/sass/css/foldr.css/sub.css
+++ b/test/samples/sass/css/foldr.css/sub.css
@@ -1,0 +1,1 @@
+#one{display:none}#two{display:none}#three{display:none}#four{display:none}body{display:none}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -16,9 +16,10 @@ suite "ForEach-cli", ()->
 			result = fs.readFileSync 'test/temp/one', {encoding:'utf8'}
 			resultLines = result.split('\n').filter (validLine)-> validLine
 
-			expect(resultLines.length).to.equal 2
-			expect(resultLines[0]).to.equal 'main.copy.css'
-			expect(resultLines[1]).to.equal 'main.css'
+			expect(resultLines.length).to.equal 3
+			expect(resultLines[0]).to.equal 'foldr.css'
+			expect(resultLines[1]).to.equal 'main.copy.css'
+			expect(resultLines[2]).to.equal 'main.css'
 		
 
 	
@@ -27,9 +28,10 @@ suite "ForEach-cli", ()->
 			result = fs.readFileSync 'test/temp/two', {encoding:'utf8'}
 			resultLines = result.split('\n').filter (validLine)-> validLine
 
-			expect(resultLines.length).to.equal 2
-			expect(resultLines[0]).to.equal 'main.copy.css'
-			expect(resultLines[1]).to.equal 'main.css'
+			expect(resultLines.length).to.equal 3
+			expect(resultLines[0]).to.equal 'foldr.css'
+			expect(resultLines[1]).to.equal 'main.copy.css'
+			expect(resultLines[2]).to.equal 'main.css'
 	
 
 
@@ -38,9 +40,10 @@ suite "ForEach-cli", ()->
 			result = fs.readFileSync 'test/temp/three', {encoding:'utf8'}
 			resultLines = result.split('\n').filter (validLine)-> validLine
 
-			expect(resultLines.length).to.equal 2
-			expect(resultLines[0]).to.equal "main.copy .css main.copy.css samples/sass/css test/samples/sass/css/main.copy.css #{process.cwd()}/test/samples/sass/css"
-			expect(resultLines[1]).to.equal "main .css main.css samples/sass/css test/samples/sass/css/main.css #{process.cwd()}/test/samples/sass/css"
+			expect(resultLines.length).to.equal 3
+			expect(resultLines[0]).to.equal "foldr .css foldr.css samples/sass/css test/samples/sass/css/foldr.css #{process.cwd()}/test/samples/sass/css"
+			expect(resultLines[1]).to.equal "main.copy .css main.copy.css samples/sass/css test/samples/sass/css/main.copy.css #{process.cwd()}/test/samples/sass/css"
+			expect(resultLines[2]).to.equal "main .css main.css samples/sass/css test/samples/sass/css/main.css #{process.cwd()}/test/samples/sass/css"
 	
 
 
@@ -49,9 +52,10 @@ suite "ForEach-cli", ()->
 			result = fs.readFileSync 'test/temp/four', {encoding:'utf8'}
 			resultLines = result.split('\n').filter (validLine)-> validLine
 
-			expect(resultLines.length).to.equal 2
-			expect(resultLines[0]).to.equal "main.copy .css main.copy.css samples/sass/css test/samples/sass/css/main.copy.css #{process.cwd()}/test/samples/sass/css"
-			expect(resultLines[1]).to.equal "main .css main.css samples/sass/css test/samples/sass/css/main.css #{process.cwd()}/test/samples/sass/css"
+			expect(resultLines.length).to.equal 3
+			expect(resultLines[0]).to.equal "foldr .css foldr.css samples/sass/css test/samples/sass/css/foldr.css #{process.cwd()}/test/samples/sass/css"
+			expect(resultLines[1]).to.equal "main.copy .css main.copy.css samples/sass/css test/samples/sass/css/main.copy.css #{process.cwd()}/test/samples/sass/css"
+			expect(resultLines[2]).to.equal "main .css main.css samples/sass/css test/samples/sass/css/main.css #{process.cwd()}/test/samples/sass/css"
 
 
 
@@ -60,20 +64,32 @@ suite "ForEach-cli", ()->
 			result = fs.readFileSync 'test/temp/five', {encoding:'utf8'}
 			resultLines = result.split('\n').filter (validLine)-> validLine
 
-			expect(resultLines.length).to.equal 1
-			expect(resultLines[0]).to.equal 'main.css'
+			expect(resultLines.length).to.equal 2
+			expect(resultLines[0]).to.equal 'foldr.css'
+			expect(resultLines[1]).to.equal 'main.css'
 
 
 
+	test "Will execute a given command on all matched files in a given glob but ignoring the folders", ()->
+		execa(bin, ['-g', 'test/samples/sass/css/*', '--nodir', 'true', '-x', 'echo {{base}} >> test/temp/six']).then (err)->
+			result = fs.readFileSync 'test/temp/six', {encoding:'utf8'}
+			resultLines = result.split('\n').filter (validLine)-> validLine
+
+			expect(resultLines.length).to.equal 2
+			expect(resultLines[0]).to.equal 'main.copy.css'
+			expect(resultLines[1]).to.equal 'main.css'
 
 
 
+	test "Will execute a given command on all matched `.css` files in a given glob with ** but ignoring the folders", ()->
+		execa(bin, ['-g', 'test/samples/sass/css/**/*.css', '--nodir', 'true', '-x', 'echo {{base}} >> test/temp/seven']).then (err)->
+			result = fs.readFileSync 'test/temp/seven', {encoding:'utf8'}
+			resultLines = result.split('\n').filter (validLine)-> validLine
 
-
-
-
-
-
+			expect(resultLines.length).to.equal 3
+			expect(resultLines[0]).to.equal 'sub.css'
+			expect(resultLines[1]).to.equal 'main.copy.css'
+			expect(resultLines[2]).to.equal 'main.css'
 
 
 


### PR DESCRIPTION
- Allow to ignore directories in our `glob` patterns
- Existing tests were adapted, as well as test files (testing `nodir`)...
- Additional tests added for `nodir`
- The version number has been adapted according to the `semver` rules. (`npm version minor`)

If you merge this PR, **please don't forget to publish it to npmjs using `npm publish`.**
NPM publish would fix https://github.com/danielkalen/foreach-cli/issues/4 too.

Thanks!